### PR TITLE
increase timeout and fix clojure deprecation warning

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -35,5 +35,6 @@ jobs:
       run: clojure -P
 
     - name: Run tests
-      run: clojure -A:test -m kaocha.runner
+      timeout-minutes: 5
+      run: clojure -M:test -m kaocha.runner
 


### PR DESCRIPTION
* default task timeout is pretty close to the expected build time